### PR TITLE
Fixed error in mapleaflet documentation and README mapleaflet example

### DIFF
--- a/R/mapleaflet.r
+++ b/R/mapleaflet.r
@@ -3,9 +3,7 @@
 #' @import leafletR
 #' @export
 #' 
-#' @param dat A data.frame, with any number of columns, but with at least the 
-#'    following: name (the taxonomic name), latitude (in dec. deg.), longitude  
-#'    (in dec. deg.)
+#' @param dat Object of class \code{occdat} as returned by \code{\link[spocc]{occ}}.
 #' @param popup If \code{TRUE} (default) popup tooltips are created for each point with
 #'    metadta for that point.
 #' @param map_provider Base map to use. One or a list of 'osm' (OpenStreetMap 

--- a/README.Rmd
+++ b/README.Rmd
@@ -96,8 +96,7 @@ head(occ2df(out)); tail(occ2df(out))
 ```{r eval=FALSE}
 spp <- c('Danaus plexippus','Accipiter striatus','Pinus contorta')
 dat <- occ(query = spp, from = 'gbif', gbifopts = list(hasCoordinate=TRUE))
-data <- occ2df(dat)
-mapleaflet(data = data, dest = ".")
+mapleaflet(data = dat, dest = ".")
 ```
 
 ![leafletmap](http://f.cl.ly/items/3w2Y1E3Z0T2T2z40310K/Screen%20Shot%202014-02-09%20at%2010.38.10%20PM.png)

--- a/README.md
+++ b/README.md
@@ -184,8 +184,7 @@ head(occ2df(out)); tail(occ2df(out))
 ```r
 spp <- c('Danaus plexippus','Accipiter striatus','Pinus contorta')
 dat <- occ(query = spp, from = 'gbif', gbifopts = list(hasCoordinate=TRUE))
-data <- occ2df(dat)
-mapleaflet(data = data, dest = ".")
+mapleaflet(data = dat, dest = ".")
 ```
 
 ![leafletmap](http://f.cl.ly/items/3w2Y1E3Z0T2T2z40310K/Screen%20Shot%202014-02-09%20at%2010.38.10%20PM.png)

--- a/man/mapleaflet.Rd
+++ b/man/mapleaflet.Rd
@@ -9,9 +9,7 @@ mapleaflet(dat, popup = TRUE, map_provider = "osm", zoom = 3,
   overwrite = TRUE, incl.data = TRUE)
 }
 \arguments{
-\item{dat}{A data.frame, with any number of columns, but with at least the
-following: name (the taxonomic name), latitude (in dec. deg.), longitude
-(in dec. deg.)}
+\item{dat}{Object of class \code{occdat} as returned by \code{\link[spocc]{occ}}.}
 
 \item{popup}{If \code{TRUE} (default) popup tooltips are created for each point with
 metadta for that point.}


### PR DESCRIPTION
I was trying the examples and noticed the mapleaflet example wasn't working. Looks like it now expects an occ object and runs occ2df itself. 